### PR TITLE
Add semantic VERSION file for canable fw

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,8 +111,9 @@ endfunction()
 # Split into two categories, F042-based and F072-based.
 
 function(add_f042_target TGTNAME)
-    execute_process(
-        COMMAND git -C ${CMAKE_CURRENT_BINARY_DIR} log -1 --format=%h
+  execute_process(
+        COMMAND bash -c "echo $(date -u +'%Y%m%d%H%M%S')-$(git -C ${CMAKE_CURRENT_BINARY_DIR} log -1 --format=%h)"
+        VERBATIM
         OUTPUT_VARIABLE versionStr
         OUTPUT_STRIP_TRAILING_WHITESPACE
     )
@@ -129,7 +130,8 @@ endfunction()
 
 function(add_f072_target TGTNAME)
     execute_process(
-        COMMAND git -C ${CMAKE_CURRENT_BINARY_DIR} log -1 --format=%h
+        COMMAND bash -c "echo $(date -u +'%Y%m%d%H%M%S')-$(git -C ${CMAKE_CURRENT_BINARY_DIR} log -1 --format=%h)"
+        VERBATIM
         OUTPUT_VARIABLE versionStr
         OUTPUT_STRIP_TRAILING_WHITESPACE
     )


### PR DESCRIPTION
Use a version string per

https://semver.org/

These filenames can be sorted using 'sort -V'.

For VERSION containing 1.0.0, the built binary is named like:

canable-1.0.0-a3cf61d.bin

And /sys/bus/usb/devices/1-3/product is:

canable gs_usb canable-1.0.0-a3cf61d

References: https://bluerivertechnology.atlassian.net/browse/PRO-8489