### PR TITLE
Add timestamp for canable fw

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,8 +111,9 @@ endfunction()
 # Split into two categories, F042-based and F072-based.
 
 function(add_f042_target TGTNAME)
-    execute_process(
-        COMMAND git -C ${CMAKE_CURRENT_BINARY_DIR} log -1 --format=%h
+  execute_process(
+        COMMAND bash -c "echo $(date -u +'%Y%m%d%H%M%S')-$(git -C ${CMAKE_CURRENT_BINARY_DIR} log -1 --format=%h)"
+        VERBATIM
         OUTPUT_VARIABLE versionStr
         OUTPUT_STRIP_TRAILING_WHITESPACE
     )
@@ -129,7 +130,8 @@ endfunction()
 
 function(add_f072_target TGTNAME)
     execute_process(
-        COMMAND git -C ${CMAKE_CURRENT_BINARY_DIR} log -1 --format=%h
+        COMMAND bash -c "echo $(date -u +'%Y%m%d%H%M%S')-$(git -C ${CMAKE_CURRENT_BINARY_DIR} log -1 --format=%h)"
+        VERBATIM
         OUTPUT_VARIABLE versionStr
         OUTPUT_STRIP_TRAILING_WHITESPACE
     )


### PR DESCRIPTION
This means that during development, multiple filenames can be present
on the filesystem, and the newest version will be used.

It also makes it easier to figure out if an image update is newer or not
during code review.

The built binary is named like:

canable-20210415215134-75cda4d.bin

And /sys/bus/usb/devices/1-3/product is:

canable gs_usb canable-20210415215134-75cda4d

References: https://bluerivertechnology.atlassian.net/browse/PRO-8489